### PR TITLE
feat: :sparkles: add M1 Max MacBook Pro

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ Options:
 | [Radxa Orion O6 - 16GB (Nvidia RTX 3080 Ti)](https://github.com/geerlingguy/ollama-benchmark/issues/13) | GPU | 64.58 Tokens/s | 465 W |
 | [M1 Ultra (48 GPU Core) 64GB](https://github.com/geerlingguy/ollama-benchmark/pull/11) | GPU | 35.89 Tokens/s | N/A |
 | [Framework Mainboard (128GB)](https://github.com/geerlingguy/ollama-benchmark/issues/21#issuecomment-3164567688) | CPU | 11.37 Tokens/s | 140W |
+| [M1 Max MacBook Pro (10 core - 32GB)](https://github.com/geerlingguy/ai-benchmarks/pull/30) | GPU | 33.95 Tokens/s | N/A |
 
 ### DeepSeek R1 671b
 
@@ -116,7 +117,7 @@ Options:
 | [DC-ROMA Mainboard II (8-core RISC-V)](https://github.com/geerlingguy/ollama-benchmark/issues/28) | CPU | 0.31 Tokens/s | 30.6 W |
 | [M4 Mac mini (10 core - 32GB)](https://github.com/geerlingguy/ollama-benchmark/issues/2) | GPU | 41.31 Tokens/s | 30.1 W |
 | M1 Max Mac Studio (10 core - 64GB) | GPU | 59.38 Tokens/s | N/A |
-| M1 Max MacBook Pro | GPU | | N/A |
+| [M1 Max MacBook Pro (10 core - 32GB)](https://github.com/geerlingguy/ai-benchmarks/pull/30) | GPU | 80.20 Tokens/s | N/A |
 | [M1 Ultra (48 GPU Core) 64GB](https://github.com/geerlingguy/ollama-benchmark/pull/11) | GPU | 108.67 Tokens/s | N/A |
 | [Ryzen 9 7900X (Nvidia 4090)](https://github.com/geerlingguy/ollama-benchmark/pull/11) | GPU | 237.05 Tokens/s | N/A |
 | [Intel 13900K (Nvidia 5090)](https://github.com/geerlingguy/ollama-benchmark/pull/18) | GPU | 271.40 Tokens/s | N/A |

--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ Options:
 | [DC-ROMA Mainboard II (8-core RISC-V)](https://github.com/geerlingguy/ollama-benchmark/issues/28) | CPU | 0.31 Tokens/s | 30.6 W |
 | [M4 Mac mini (10 core - 32GB)](https://github.com/geerlingguy/ollama-benchmark/issues/2) | GPU | 41.31 Tokens/s | 30.1 W |
 | M1 Max Mac Studio (10 core - 64GB) | GPU | 59.38 Tokens/s | N/A |
+| M1 Max MacBook Pro | GPU | | N/A |
 | [M1 Ultra (48 GPU Core) 64GB](https://github.com/geerlingguy/ollama-benchmark/pull/11) | GPU | 108.67 Tokens/s | N/A |
 | [Ryzen 9 7900X (Nvidia 4090)](https://github.com/geerlingguy/ollama-benchmark/pull/11) | GPU | 237.05 Tokens/s | N/A |
 | [Intel 13900K (Nvidia 5090)](https://github.com/geerlingguy/ollama-benchmark/pull/18) | GPU | 271.40 Tokens/s | N/A |


### PR DESCRIPTION
```shell
                    'c.          supporterino@Freya-II
                 ,xNMM.          ---------------------
               .OMMMMo           OS: macOS 26.0.1 25A362 arm64
               OMMM0,            Host: MacBookPro18,4
     .;loddo:' loolloddol;.      Kernel: 25.0.0
   cKMMMMMMMMMMNWMMMMMMMMMM0:    Uptime: 6 days, 4 hours, 22 mins
 .KMMMMMMMMMMMMMMMMMMMMMMMWd.    Packages: 209 (brew)
 XMMMMMMMMMMMMMMMMMMMMMMMX.      Shell: zsh 5.9
;MMMMMMMMMMMMMMMMMMMMMMMM:       Resolution: 1800x1169
:MMMMMMMMMMMMMMMMMMMMMMMM:       DE: Aqua
.MMMMMMMMMMMMMMMMMMMMMMMMX.      WM: Quartz Compositor
 kMMMMMMMMMMMMMMMMMMMMMMMMWd.    WM Theme: Blue (Dark)
 .XMMMMMMMMMMMMMMMMMMMMMMMMMMk   Terminal: iTerm2
  .XMMMMMMMMMMMMMMMMMMMMMMMMK.   Terminal Font: MesloLGS-NF-Regular 13
    kMMMMMMMMMMMMMMMMMMMMMMd     CPU: Apple M1 Max
     ;KMMMMMMMWXXWMMMMMMMk.      GPU: Apple M1 Max
       .cooc,.    .,coo:.        Memory: 4747MiB / 32768MiB
```

`llama3.2:3b`
---
running benchmark 3 times using model: llama3.2:3b

| Run | Eval Rate (Tokens/Second) |
|-----|-----------------------------|
| 1 | 80.32 tokens/s |
| 2 | 80.11 tokens/s |
| 3 | 80.17 tokens/s |
|**Average Eval Rate**| 80.20 tokens/second |

`deepseek-r1`
---
Running benchmark 3 times using model: deepseek-r1

| Run | Eval Rate (Tokens/Second) |
|-----|-----------------------------|
| 1 | 35.99 tokens/s |
| 2 | 33.12 tokens/s |
| 3 | 32.74 tokens/s |
|**Average Eval Rate**| 33.95 tokens/second |